### PR TITLE
Fix local variable referenced before assignment

### DIFF
--- a/qlyrx.py
+++ b/qlyrx.py
@@ -271,8 +271,7 @@ class qlyrx:
         self.fd.setFileMode(QFileDialog.ExistingFile)
         self.fd.setNameFilter("QGIS Layer Style File, SLD File (*.qml *.sld )")
         if self.fd.exec_() == QDialog.Accepted:
-            fileName = self.fd.selectedFiles()
-            file = fileName[0]
+            file = str(self.fd.selectedFiles()[0])
             if file.endswith('sld'):
                 layer.loadSldStyle(file)
             elif file.endswith('qml'):

--- a/qlyrx.py
+++ b/qlyrx.py
@@ -270,7 +270,7 @@ class qlyrx:
         self.fd.show()
         self.fd.setFileMode(QFileDialog.ExistingFile)
         self.fd.setNameFilter("QGIS Layer Style File, SLD File (*.qml *.sld )")
-        if self.fd.exec_():
+        if self.fd.exec_() == QDialog.Accepted:
             fileName = self.fd.selectedFiles()
             file = fileName[0]
             if file.endswith('sld'):

--- a/qlyrx.py
+++ b/qlyrx.py
@@ -273,11 +273,11 @@ class qlyrx:
         if self.fd.exec_():
             fileName = self.fd.selectedFiles()
             file = fileName[0]
-        if file.endswith('sld'):
-            layer.loadSldStyle(file)
-        elif file.endswith('qml'):
-            layer.loadNamedStyle(file)
-        layer.triggerRepaint()
+            if file.endswith('sld'):
+                layer.loadSldStyle(file)
+            elif file.endswith('qml'):
+                layer.loadNamedStyle(file)
+            layer.triggerRepaint()
 
 
     def load_vectors(self):


### PR DESCRIPTION
In case `exec()` fails (e.g. user pressed cancel button), we get
UnboundLocalError: local variable 'file' referenced before assignment
on
`    if file.endswith('sld'):`